### PR TITLE
"Safer" use of ruby gsub

### DIFF
--- a/recipes/metadata/escape_column_name.sh
+++ b/recipes/metadata/escape_column_name.sh
@@ -19,7 +19,7 @@ ruby <<'EOF'
 name = "a_c"
 puts name
 #@ _RUBY_
-name.gsub!(/([%_])/, '\\\\\1')
+name = name.gsub(/([%_])/, '\\\\\1')
 #@ _RUBY_
 puts name
 EOF


### PR DESCRIPTION
From the 3rd edition of the book:

> The need to escape % and _ characters to match a LIKE pattern literally also applies to other SHOW statements that permit a name pattern in the LIKE clause, such as SHOW TABLES and SHOW DATABASES.
Within a program, you can use your API language’s pattern-matching capabilities to escape SQL pattern characters before putting the column name into a SHOW statement. In Perl, Ruby, and PHP, use the following expressions.
> Perl:
$name =~ s/([%_])/\\$1/g; 
> Ruby:
name.gsub!(/([%_])/, '\\\\\1')

`gsub!()` does an in-place regex string replace, so the value for `name` is changed, as expected; but it will return 2 different types of things:
- the new value in `name`, if the regex matched,
- `nil` if there was no match

This is a mechanism that will tell you if a match and replacement took place (e.g., nil = nope), but it's unexpected and surprising behaviour, and a new developer might make a mistake with it. The regular `gsub()` function, in contrast, doesn't change the original variable's value, but does the replacement and returns whatever the new string is, changed or unchanged.

I recommend going with plain gsub(), and assigning it back to the variable. This is based on advice from professional ruby developers I spoke with. 

The line showed up in section 12.7 Accessing Table Column Definitions. I added a note there too.


