### PR TITLE
fix indenting on ruby script

### DIFF
--- a/recipes/stats/rank.rb
+++ b/recipes/stats/rank.rb
@@ -21,11 +21,11 @@ rank = 0
 prev_score = nil
 puts "Row\tRank\tScore\n"
 res.each do |row|
-	score = row.values[0]
-	rownum += 1
-	rank = rownum if rownum == 1 || prev_score != score
-	prev_score = score
-	puts "#{rownum}\t#{rank}\t#{score}"
+  score = row.values[0]
+  rownum += 1
+  rank = rownum if rownum == 1 || prev_score != score
+  prev_score = score
+  puts "#{rownum}\t#{rank}\t#{score}"
 end
 #@ _ASSIGN_RANKS_
 


### PR DESCRIPTION
I just noticed this indenting issue from the book excerpt.

I am wondering though: why does the script create and populate a `t` table? The `ranks` table is included in the tables directory.