### PR TITLE
Quick edit rows affected to rows matched

### DIFF
--- a/recipes/metadata/affected_rows.rb
+++ b/recipes/metadata/affected_rows.rb
@@ -41,5 +41,5 @@ client = Mysql2::Client.new(:database => "cookbook",
 # be nonzero due to the use of mysql_client_found_rows
 stmt = "UPDATE limbs SET arms = 0 WHERE arms = 0"
 client.query(stmt)
-puts "Number of rows affected: #{client.affected_rows}"
+puts "Number of rows matched: #{client.affected_rows}"
 client.close


### PR DESCRIPTION
The 3rd update statement is using the found-rows flag and so it returns the number of rows matched, not rows affected. 

Related: I think Cookbook.rb should be more modular, since in my setup I had it connecting via tcp/ip in Cookbook.rb and then this script suddenly uses localhost for its 3rd update.