### PR TITLE
cursor.description output count incorrect?

### DIFF
--- a/recipes/metadata/get_rs_meta.py
+++ b/recipes/metadata/get_rs_meta.py
@@ -41,7 +41,7 @@ try:
   else:
     for i, col_info in enumerate(cursor.description):
       # print name, then other information
-      name, type, _, _, _, _, nullable, flags = col_info
+      name, type, _, _, _, _, nullable, flags, _ = col_info
       print("--- Column %d (%s) ---" % (i, name))
       print("Type:     %d (%s)" % (type, FieldType.get_info(type)))
       print("Nullable: %d" % (nullable))


### PR DESCRIPTION
In testing I found this script didn't work right for cursor.description. According to the docs (https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-description.html) it should return 8 tuples, but for me it returns an extra tuple after the flags one.

Running the code as-is I get:

```
# python3 get_rs_meta.py
Statement: SELECT name, birth FROM profile
Number of rows: 26
Number of columns: 2
Traceback (most recent call last):
  File "get_rs_meta.py", line 44, in <module>
    name, type, _, _, _, _, nullable, flags = col_info
ValueError: too many values to unpack (expected 8)
```

Adding an "extra" var to the end, I can get it to print out:

```
# python3 get_rs_meta.py
Statement: SELECT name, birth FROM profile
Number of rows: 26
Number of columns: 2
--- Column 0 (name) ---
Type:     253 (VAR_STRING)
Nullable: 0
Flags:    4097
Extra:    45
--- Column 1 (birth) ---
Type:     10 (DATE)
Nullable: 1
Flags:    128
Extra:    63
```

I got it working the intended way by ignoring the 9th tuple, but I'm not sure why that tuple is happening at all, and what it's a symptom of. Maybe double-check this?

This is using MySQL 8.0.27, Python 3.7.3, mysql.connector 8.0.26 on linux, but it does the same thing on MacOS.